### PR TITLE
ci: fix "no such tool covdata" by pinning Go via go-version-file

### DIFF
--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version-file: go.mod
 
       - name: Build
         # this generates up-to-date completion scripts in the build directory

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version-file: go.mod
 
       - name: Install
         run: make install

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/sha1n/go-template
 
-go 1.21
-
-// toolchain go1.21.1
+go 1.25.0


### PR DESCRIPTION
## Problem

The CI **Go** job fails with:

```
# github.com/sha1n/go-template/generated/example
go: no such tool "covdata"
```

This is unrelated to any dependabot bump (e.g. #49 / actions/checkout) — it surfaces on every PR right now.

## Root cause

1. `setup-go` pins **Go 1.21**.
2. The `make install` step runs `go get .../grpc/cmd/protoc-gen-go-grpc`, which bumps the `go.mod` `go` directive **`1.21 → 1.25.0`** (current grpc requires it).
3. With `GOTOOLCHAIN=auto`, the test step **switches up** to an auto-downloaded go1.25 toolchain.
4. Go bug [golang/go#75031](https://github.com/golang/go/issues/75031): with a *switched* toolchain, `go test -cover` on a package with **no test files** can't locate the `covdata` tool. The generated, test-free `generated/example` package triggers it; `cmd` has a test so it passes.

Reproduced locally with a real go1.21 primary switching up to 1.25 (fails) vs. an installed toolchain that already satisfies go.mod (passes).

## Fix

Eliminate the toolchain switch so the installed full toolchain (which has working `covdata`) is used directly:

- `go.mod`: declare the honest module floor `go 1.25.0` (drops the stale `// toolchain go1.21.1` comment).
- `go.yml` & `go-releaser.yml`: drive `setup-go` from `go-version-file: go.mod` instead of the hard-coded `go-version: 1.21`, making go.mod the single source of truth.

Refs: https://github.com/golang/go/issues/75031